### PR TITLE
refactor: Store 조회 메서드 권한에 맞게 변경

### DIFF
--- a/src/main/java/com/i3/delivery/domain/store/controller/StoreController.java
+++ b/src/main/java/com/i3/delivery/domain/store/controller/StoreController.java
@@ -34,15 +34,17 @@ public class StoreController {
     @GetMapping
     public Page<StoreInfoResponseDto> getAllStore(@PageableDefault(page = 0, size = 10,
             sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-                                                  @RequestParam Integer size){
+                                                  @RequestParam Integer size,
+                                                  @AuthenticationPrincipal UserDetailsImpl userDetails){
 
-        return storeService.getStores(pageable,size);
+        return storeService.getStores(userDetails.getUser(), pageable, size);
     }
 
     @GetMapping("/{id}")
-    public StoreInfoResponseDto getStore(@PathVariable(name = "id") Long id) {
+    public StoreInfoResponseDto getStore(@PathVariable(name = "id") Long id,
+                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        return storeService.getStore(id);
+        return storeService.getStore(id,userDetails.getUser());
     }
 
     @GetMapping("/keyword/{keyword}")

--- a/src/main/java/com/i3/delivery/domain/store/repository/custom/StoreRepositoryCustom.java
+++ b/src/main/java/com/i3/delivery/domain/store/repository/custom/StoreRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.i3.delivery.domain.store.repository.custom;
 
+import com.i3.delivery.domain.store.dto.StoreInfoResponseDto;
 import com.i3.delivery.domain.store.dto.StoreReviewResponseDto;
 import com.i3.delivery.domain.store.dto.StoreReviewResponsePage;
 import com.i3.delivery.domain.store.entity.Store;
+import com.i3.delivery.domain.user.entity.User;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -10,4 +13,6 @@ import java.util.List;
 public interface StoreRepositoryCustom {
     List<Store> findAll(String keyword, Pageable pageable);
     StoreReviewResponsePage<StoreReviewResponseDto> findStoreReviewAvgAndReviews(String name, Pageable pageable, int size);
+    Page<StoreInfoResponseDto> findStores(User user, Pageable pageable, int size);
+    Page<StoreInfoResponseDto> findStoresMaster(User user, Pageable pageable, int size);
 }

--- a/src/main/java/com/i3/delivery/domain/store/repository/custom/impl/StoreRepositoryImpl.java
+++ b/src/main/java/com/i3/delivery/domain/store/repository/custom/impl/StoreRepositoryImpl.java
@@ -31,7 +31,6 @@ public class StoreRepositoryImpl extends QuerydslRepositorySupport implements St
         this.queryFactory = queryFactory;
     }
 
-    // TODO Paging (+ Sorting)
     @Override
     public List<Store> findAll(String keyword, Pageable pageable){
         List<Store> stores = queryFactory

--- a/src/main/java/com/i3/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/com/i3/delivery/domain/store/service/StoreService.java
@@ -105,7 +105,6 @@ public class StoreService {
 
     }
 
-    // TODO 여기서 transanctional 이 필요할까요?? 만약 쓴다면 readOnly = true 로 설정해주세요.
     @Transactional
     public StoreReviewResponsePage<StoreReviewResponseDto> getStoreReviewAvgAndReviews(String name,Pageable pageable,int size) {
 

--- a/src/main/java/com/i3/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/com/i3/delivery/domain/store/service/StoreService.java
@@ -8,7 +8,9 @@ import com.i3.delivery.domain.store.enums.StoreStatus;
 import com.i3.delivery.domain.store.repository.StoreRepository;
 import com.i3.delivery.domain.store.repository.custom.impl.StoreRepositoryImpl;
 import com.i3.delivery.domain.user.entity.User;
+import com.i3.delivery.domain.user.entity.UserRoleEnum;
 import com.i3.delivery.domain.user.repository.UserRepository;
+import com.i3.delivery.global.exception.store.StoreDeletedException;
 import com.i3.delivery.global.exception.store.StoreNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -58,22 +60,29 @@ public class StoreService {
         return StoreRegistrationResponseDto.fromEntity(store);
     }
 
-    public Page<StoreInfoResponseDto> getStores(Pageable pageable, int size) {
+    public Page<StoreInfoResponseDto> getStores(User user,Pageable pageable, int size) {
 
-        pageable = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
-
-        return storeRepository.findAll(pageable).
-                map(StoreInfoResponseDto::fromEntity);
+        if(user.getRole().equals(UserRoleEnum.MANAGER) || user.getRole().equals(UserRoleEnum.MASTER)){
+            return storeRepositoryImpl.findStoresMaster(user,pageable,size);
+        }
+        return storeRepositoryImpl.findStores(user,pageable,size);
     }
 
-    public StoreInfoResponseDto getStore(Long id) {
+    public StoreInfoResponseDto getStore(Long id, User user) {
 
         Store store = storeRepository.findById(id).orElse(null);
+
+        if(Objects.requireNonNull(store).getDeletedAt() != null){
+            if(user.getRole().equals(UserRoleEnum.MASTER) || user.getRole().equals(UserRoleEnum.MANAGER)){
+                return StoreInfoResponseDto.fromEntity(Objects.requireNonNull(store));
+            }else{
+                throw new StoreDeletedException();
+            }
+        }
 
         return StoreInfoResponseDto.fromEntity(Objects.requireNonNull(store));
     }
 
-    @Transactional
     public List<StoreInfoResponseDto> getStoresByKeyword(String keyword,Pageable pageable, int size) {
 
         pageable = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());

--- a/src/main/java/com/i3/delivery/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/i3/delivery/global/exception/common/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
 
     // Store
     NOT_FOUND_STORE_EXCEPTION(404, "해당 가게를 찾을 수 없습니다."),
+    DELETED_STORE_EXCEPTION(404, "해당 가게는 삭제된 상태입니다."),
+    NOT_STORE_MANAGER_OR_MASTER(404, "해당 가게의 매니저나 마스터가 아닙니다."),
 
     // Product
     NOT_FOUND_PRODUCT_EXCEPTION(404, "해당 상품을 찾을 수 없습니다."),

--- a/src/main/java/com/i3/delivery/global/exception/store/NotStoreManagerOrMaster.java
+++ b/src/main/java/com/i3/delivery/global/exception/store/NotStoreManagerOrMaster.java
@@ -1,0 +1,12 @@
+package com.i3.delivery.global.exception.store;
+
+import com.i3.delivery.global.exception.common.BusinessException;
+import com.i3.delivery.global.exception.common.ErrorCode;
+
+
+public class NotStoreManagerOrMaster extends BusinessException {
+
+    public NotStoreManagerOrMaster() {
+        super(ErrorCode.NOT_STORE_MANAGER_OR_MASTER);
+    }
+}

--- a/src/main/java/com/i3/delivery/global/exception/store/StoreDeletedException.java
+++ b/src/main/java/com/i3/delivery/global/exception/store/StoreDeletedException.java
@@ -1,0 +1,11 @@
+package com.i3.delivery.global.exception.store;
+
+import com.i3.delivery.global.exception.common.BusinessException;
+import com.i3.delivery.global.exception.common.ErrorCode;
+
+public class StoreDeletedException extends BusinessException {
+
+    public StoreDeletedException() {
+        super(ErrorCode.DELETED_STORE_EXCEPTION);
+    }
+}


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
getStores, getStore 메서드 변경
1. Store 조회 시 권한에 따른 조회범위 수정
Master, Manager를 제외한 권한은 createAt과 같은 데이터가 null로 나옴.

2. 삭제된 가게 조회 시 Master,Manager만 조회할 수 있게 변경

3. 삭제된 가게/권한 오류 핸들러 추가

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
